### PR TITLE
Fix install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ install_cmd() {
     bin/rake "rhconsulting:miq_ae_datastore:import[${DOMAIN}, ${TOPDIR}/Automate]"
 
     echo "Importing Service Dialogs"
-    bin/rake rhconsulting:dialogs:import[${TOPDIR}/ServiceDialogs]
+    bin/rake rhconsulting:service_dialogs:import[${TOPDIR}/ServiceDialogs]
  
     echo "Importing Buttons"
     bin/rake rhconsulting:buttons:import[${TOPDIR}/Buttons/buttons.yml]


### PR DESCRIPTION
Add service_ to the service_dialog rake.

Dialog import was failing on install when I was testing this out. Found that the rhconsulting import script was actually named with service_dialogs instead of just dialogs. 
